### PR TITLE
feat: `lines()`, `linesIter()` and sync methods

### DIFF
--- a/_fs.ts
+++ b/_fs.ts
@@ -159,6 +159,21 @@ export class FsFile {
     return fs.writeSync(this._fd, bytes, 0, bytes.length);
   }
 
+  /** Reads into `buf`, resolving to the number of bytes read (0 at EOF). */
+  read(buf: Uint8Array): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
+      fs.read(this._fd, buf, 0, buf.length, null, (err, bytesRead: number) => {
+        if (err) reject(err);
+        else resolve(bytesRead);
+      });
+    });
+  }
+
+  /** Synchronously reads into `buf`, returning the number of bytes read (0 at EOF). */
+  readSync(buf: Uint8Array): number {
+    return fs.readSync(this._fd, buf, 0, buf.length, null);
+  }
+
   /** Closes the file handle. */
   close(): void {
     fs.closeSync(this._fd);

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -621,42 +621,63 @@ test("readMaybeText", async () => {
 test("lines", async () => {
   await withTempDir(async () => {
     const file = new Path("file.txt");
+    const cases: { content: string; expected: string[] }[] = [
+      // trailing newline is not a blank line
+      { content: "a\nb\n", expected: ["a", "b"] },
+      // no trailing newline
+      { content: "a\nb", expected: ["a", "b"] },
+      // \r\n line endings
+      { content: "a\r\nb\r\n", expected: ["a", "b"] },
+      // embedded blank lines are preserved
+      { content: "a\n\nb", expected: ["a", "", "b"] },
+      // double trailing newline drops only one
+      { content: "a\n\n", expected: ["a", ""] },
+      // standalone \r is part of the line
+      { content: "a\rb\n", expected: ["a\rb"] },
+      // empty file
+      { content: "", expected: [] },
+      // single newline
+      { content: "\n", expected: [""] },
+    ];
+    for (const { content, expected } of cases) {
+      file.writeSync(content);
+      assertEquals(await file.lines(), expected, `lines ${inspect(content)}`);
+      assertEquals(
+        file.linesSync(),
+        expected,
+        `linesSync ${inspect(content)}`,
+      );
+      const iterAsync: string[] = [];
+      for await (const line of file.linesIter()) iterAsync.push(line);
+      assertEquals(iterAsync, expected, `linesIter ${inspect(content)}`);
+      assertEquals(
+        Array.from(file.linesIterSync()),
+        expected,
+        `linesIterSync ${inspect(content)}`,
+      );
+    }
+  });
+});
 
-    // trailing newline is not a blank line
-    file.writeSync("a\nb\n");
-    assertEquals(await file.lines(), ["a", "b"]);
-    assertEquals(file.linesSync(), ["a", "b"]);
+test("linesIter streams across read-buffer boundaries", async () => {
+  await withTempDir(async () => {
+    const file = new Path("big.txt");
+    // build ~200KB across ~2000 lines with mixed \n and \r\n,
+    // larger than the 16KB internal read buffer
+    const expected: string[] = [];
+    const parts: string[] = [];
+    for (let i = 0; i < 2000; i++) {
+      const line = `line-${i}-` + "x".repeat((i % 97) + 5);
+      expected.push(line);
+      parts.push(line);
+      parts.push(i % 2 === 0 ? "\n" : "\r\n");
+    }
+    file.writeSync(parts.join(""));
 
-    // no trailing newline
-    file.writeSync("a\nb");
-    assertEquals(file.linesSync(), ["a", "b"]);
-
-    // \r\n line endings
-    file.writeSync("a\r\nb\r\n");
-    assertEquals(file.linesSync(), ["a", "b"]);
-
-    // embedded blank lines are preserved
-    file.writeSync("a\n\nb");
-    assertEquals(file.linesSync(), ["a", "", "b"]);
-
-    // double trailing newline drops only one
-    file.writeSync("a\n\n");
-    assertEquals(file.linesSync(), ["a", ""]);
-
-    // standalone \r is part of the line
-    file.writeSync("a\rb\n");
-    assertEquals(file.linesSync(), ["a\rb"]);
-
-    // empty file
-    file.writeSync("");
-    assertEquals(file.linesSync(), []);
-
-    // iterator variants
-    file.writeSync("a\nb\n");
-    const asyncLines = [];
+    const asyncLines: string[] = [];
     for await (const line of file.linesIter()) asyncLines.push(line);
-    assertEquals(asyncLines, ["a", "b"]);
-    assertEquals(Array.from(file.linesIterSync()), ["a", "b"]);
+    assertEquals(asyncLines, expected);
+    assertEquals(Array.from(file.linesIterSync()), expected);
   });
 });
 

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -618,6 +618,48 @@ test("readMaybeText", async () => {
   });
 });
 
+test("lines", async () => {
+  await withTempDir(async () => {
+    const file = new Path("file.txt");
+
+    // trailing newline is not a blank line
+    file.writeSync("a\nb\n");
+    assertEquals(await file.lines(), ["a", "b"]);
+    assertEquals(file.linesSync(), ["a", "b"]);
+
+    // no trailing newline
+    file.writeSync("a\nb");
+    assertEquals(file.linesSync(), ["a", "b"]);
+
+    // \r\n line endings
+    file.writeSync("a\r\nb\r\n");
+    assertEquals(file.linesSync(), ["a", "b"]);
+
+    // embedded blank lines are preserved
+    file.writeSync("a\n\nb");
+    assertEquals(file.linesSync(), ["a", "", "b"]);
+
+    // double trailing newline drops only one
+    file.writeSync("a\n\n");
+    assertEquals(file.linesSync(), ["a", ""]);
+
+    // standalone \r is part of the line
+    file.writeSync("a\rb\n");
+    assertEquals(file.linesSync(), ["a\rb"]);
+
+    // empty file
+    file.writeSync("");
+    assertEquals(file.linesSync(), []);
+
+    // iterator variants
+    file.writeSync("a\nb\n");
+    const asyncLines = [];
+    for await (const line of file.linesIter()) asyncLines.push(line);
+    assertEquals(asyncLines, ["a", "b"]);
+    assertEquals(Array.from(file.linesIterSync()), ["a", "b"]);
+  });
+});
+
 test("readJson", async () => {
   await withTempDir(async () => {
     const file = new Path("file.txt");

--- a/mod.ts
+++ b/mod.ts
@@ -649,7 +649,7 @@ export class Path {
    * [Rust's `str::lines`](https://doc.rust-lang.org/std/primitive.str.html#method.lines)).
    */
   async lines(options?: _fs.ReadFileOptions): Promise<string[]> {
-    return splitLines(await this.readText(options));
+    return [...splitLines(await this.readText(options))];
   }
 
   /** Synchronously reads the file's text and returns an array of its lines.
@@ -657,25 +657,85 @@ export class Path {
    * See `.lines()` for the splitting semantics.
    */
   linesSync(): string[] {
-    return splitLines(this.readTextSync());
+    return [...splitLines(this.readTextSync())];
   }
 
-  /** Reads the file's text and iterates over its lines.
+  /** Streams the file and iterates over its lines without loading it all into memory.
    *
    * See `.lines()` for the splitting semantics.
    */
   async *linesIter(
     options?: _fs.ReadFileOptions,
   ): AsyncIterableIterator<string> {
-    yield* splitLines(await this.readText(options));
+    const file = await _fs.openFile(this.#path, { read: true });
+    try {
+      const decoder = new TextDecoder();
+      const chunk = new Uint8Array(16384);
+      let buffer = "";
+      while (true) {
+        options?.signal?.throwIfAborted();
+        const n = await file.read(chunk);
+        if (n === 0) break;
+        buffer += decoder.decode(chunk.subarray(0, n), { stream: true });
+        let start = 0;
+        while (true) {
+          const nl = buffer.indexOf("\n", start);
+          if (nl === -1) break;
+          const end = nl > start && buffer.charCodeAt(nl - 1) === 13
+            ? nl - 1
+            : nl;
+          yield buffer.substring(start, end);
+          start = nl + 1;
+        }
+        if (start > 0) buffer = buffer.substring(start);
+      }
+      buffer += decoder.decode();
+      if (buffer !== "") yield buffer;
+    } finally {
+      try {
+        file.close();
+      } catch {
+        // ignore
+      }
+    }
   }
 
-  /** Synchronously reads the file's text and iterates over its lines.
+  /** Synchronously streams the file and iterates over its lines without
+   * loading it all into memory.
    *
    * See `.lines()` for the splitting semantics.
    */
   *linesIterSync(): IterableIterator<string> {
-    yield* splitLines(this.readTextSync());
+    const file = _fs.openFileSync(this.#path, { read: true });
+    try {
+      const decoder = new TextDecoder();
+      const chunk = new Uint8Array(16384);
+      let buffer = "";
+      while (true) {
+        const n = file.readSync(chunk);
+        if (n === 0) break;
+        buffer += decoder.decode(chunk.subarray(0, n), { stream: true });
+        let start = 0;
+        while (true) {
+          const nl = buffer.indexOf("\n", start);
+          if (nl === -1) break;
+          const end = nl > start && buffer.charCodeAt(nl - 1) === 13
+            ? nl - 1
+            : nl;
+          yield buffer.substring(start, end);
+          start = nl + 1;
+        }
+        if (start > 0) buffer = buffer.substring(start);
+      }
+      buffer += decoder.decode();
+      if (buffer !== "") yield buffer;
+    } finally {
+      try {
+        file.close();
+      } catch {
+        // ignore
+      }
+    }
   }
 
   /** Reads and parses the file as JSON, throwing if it doesn't exist or is not valid JSON. */
@@ -1353,10 +1413,20 @@ function writeAllSync(
   }
 }
 
-function splitLines(text: string): string[] {
-  if (text === "") return [];
-  const lines = text.split(/\r?\n/);
-  // matches Rust: trailing final line ending produces no blank line
-  if (text.endsWith("\n")) lines.pop();
-  return lines;
+function* splitLines(text: string): Generator<string> {
+  if (text === "") return;
+  let start = 0;
+  while (true) {
+    const nl = text.indexOf("\n", start);
+    if (nl === -1) {
+      if (start < text.length) yield text.substring(start);
+      return;
+    }
+    // strip \r when it immediately precedes \n
+    const end = nl > start && text.charCodeAt(nl - 1) === 13 ? nl - 1 : nl;
+    yield text.substring(start, end);
+    start = nl + 1;
+    // a final line ending does not produce a trailing blank line
+    if (start === text.length) return;
+  }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -642,6 +642,42 @@ export class Path {
     return notFoundToUndefinedSync(() => this.readTextSync());
   }
 
+  /** Reads the file's text and returns an array of its lines.
+   *
+   * Lines are split at `\n` or `\r\n`. Line terminators are not included.
+   * A trailing blank line caused by a final line ending is excluded (matches
+   * [Rust's `str::lines`](https://doc.rust-lang.org/std/primitive.str.html#method.lines)).
+   */
+  async lines(options?: _fs.ReadFileOptions): Promise<string[]> {
+    return splitLines(await this.readText(options));
+  }
+
+  /** Synchronously reads the file's text and returns an array of its lines.
+   *
+   * See `.lines()` for the splitting semantics.
+   */
+  linesSync(): string[] {
+    return splitLines(this.readTextSync());
+  }
+
+  /** Reads the file's text and iterates over its lines.
+   *
+   * See `.lines()` for the splitting semantics.
+   */
+  async *linesIter(
+    options?: _fs.ReadFileOptions,
+  ): AsyncIterableIterator<string> {
+    yield* splitLines(await this.readText(options));
+  }
+
+  /** Synchronously reads the file's text and iterates over its lines.
+   *
+   * See `.lines()` for the splitting semantics.
+   */
+  *linesIterSync(): IterableIterator<string> {
+    yield* splitLines(this.readTextSync());
+  }
+
   /** Reads and parses the file as JSON, throwing if it doesn't exist or is not valid JSON. */
   async readJson<T>(options?: _fs.ReadFileOptions): Promise<T> {
     return this.#parseJson<T>(await this.readText(options));
@@ -1315,4 +1351,12 @@ function writeAllSync(
     signal?.throwIfAborted();
     nwritten += writer.writeSync(data.subarray(nwritten));
   }
+}
+
+function splitLines(text: string): string[] {
+  if (text === "") return [];
+  const lines = text.split(/\r?\n/);
+  // matches Rust: trailing final line ending produces no blank line
+  if (text.endsWith("\n")) lines.pop();
+  return lines;
 }


### PR DESCRIPTION
Closes https://github.com/dsherret/path/issues/4